### PR TITLE
Fix image test broken by PHP upgrade.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <XML>
+      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (1)" />
+  </state>
+</component>

--- a/.idea/php7-mapnik.iml
+++ b/.idea/php7-mapnik.iml
@@ -4,27 +4,5 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library">
-      <library name="PHP" type="php">
-        <CLASSES>
-          <root url="file://$APPLICATION_HOME_DIR$/bin" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="file://$APPLICATION_HOME_DIR$/bin" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library name="PHARS">
-        <CLASSES>
-          <root url="phar://$MODULE_DIR$/vendor/twig/twig/test/Twig/Tests/Loader/Fixtures/phar/phar-sample.phar/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="phar://$MODULE_DIR$/vendor/twig/twig/test/Twig/Tests/Loader/Fixtures/phar/phar-sample.phar/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
   </component>
 </module>

--- a/tests/image.phpt
+++ b/tests/image.phpt
@@ -3,7 +3,7 @@
 --EXTENSIONS--
 gd
 --SKIPIF--
-<?php if (!extension_loaded("mapnik")) print "skip"; ?>
+<?php if (!extension_loaded("mapnik") || !extension_loaded("gd")) print "skip"; ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
After PHP 7.1.17 update from Webtatic repository (https://webtatic.com/news/2018/05/latest-updates-php-7.2.5-7.1.17-7.0.30-5.6.36/) issues with loading GD and the image.phpt test appeared. This change is a quick fix that simply skips that test if GD is not loaded. It may never be loaded as the --EXTENTIONS-- section of the test can't seem to find the module.